### PR TITLE
Rework `set_suffix_array_mem` method of SufrFile to avoid redundant re-loading

### DIFF
--- a/libsufr/src/sufr_file.rs
+++ b/libsufr/src/sufr_file.rs
@@ -100,8 +100,6 @@ where
     /// File access wrapper to the LCP array
     pub lcp_file: FileAccess<T>,
 
-    is_in_mem: bool,
-
     /// In-memory access to the suffix array
     suffix_array_mem: Vec<T>,
 
@@ -270,7 +268,6 @@ where
             suffix_array_file,
             lcp_file,
             text_file,
-            is_in_mem: false,
             suffix_array_mem: vec![],
             suffix_array_mem_mql: None,
             suffix_array_rank_mem: vec![],
@@ -515,9 +512,6 @@ where
     /// Args:
     /// * `max_query_len`: prefix length
     fn set_suffix_array_mem(&mut self, max_query_len: Option<usize>) -> Result<()> {
-        if self.is_in_mem {
-            return Ok(())
-        }
 
         let mut max_query_len = max_query_len.unwrap_or(0);
 
@@ -670,8 +664,6 @@ where
                 }
             }
         }
-
-        self.is_in_mem = true;
 
         Ok(())
     }

--- a/libsufr/src/sufr_file.rs
+++ b/libsufr/src/sufr_file.rs
@@ -100,6 +100,8 @@ where
     /// File access wrapper to the LCP array
     pub lcp_file: FileAccess<T>,
 
+    is_in_mem: bool,
+
     /// In-memory access to the suffix array
     suffix_array_mem: Vec<T>,
 
@@ -268,6 +270,7 @@ where
             suffix_array_file,
             lcp_file,
             text_file,
+            is_in_mem: false,
             suffix_array_mem: vec![],
             suffix_array_mem_mql: None,
             suffix_array_rank_mem: vec![],
@@ -512,6 +515,10 @@ where
     /// Args:
     /// * `max_query_len`: prefix length
     fn set_suffix_array_mem(&mut self, max_query_len: Option<usize>) -> Result<()> {
+        if self.is_in_mem {
+            return Ok(())
+        }
+
         let mut max_query_len = max_query_len.unwrap_or(0);
 
         // If ".sufr" file was built with a nonzero max_query_len or seed mask
@@ -663,6 +670,8 @@ where
                 }
             }
         }
+
+        self.is_in_mem = true;
 
         Ok(())
     }

--- a/libsufr/src/sufr_file.rs
+++ b/libsufr/src/sufr_file.rs
@@ -536,6 +536,14 @@ where
             }
         }
 
+        // Do nothing if we've already loaded the correct SA/MQL
+        if !self.suffix_array_mem.is_empty()
+            && self.suffix_array_mem_mql == Some(max_query_len)
+        {
+            info!("Using existing suffix_array_mem");
+            return Ok(());
+        }
+
         // The requested MQL matches how the SA was built
         if max_query_len == built_max_query_len {
             // Stuff entire SA into memory
@@ -547,13 +555,6 @@ where
             // There will be no ranks
             self.suffix_array_rank_mem = vec![];
         } else {
-            // Do nothing if we've already loaded the correct SA/MQL
-            if !self.suffix_array_mem.is_empty()
-                && self.suffix_array_mem_mql == Some(max_query_len)
-            {
-                info!("Using existing suffix_array_mem");
-                return Ok(());
-            }
 
             info!("Loading suffix_array_mem using max_query_len {max_query_len}");
 
@@ -620,7 +621,6 @@ where
             } else {
                 let now = Instant::now();
                 let (sub_sa, sub_rank) = &self.subsample_suffix_array(max_query_len);
-                self.suffix_array_mem_mql = Some(max_query_len);
                 self.suffix_array_mem = sub_sa.to_vec();
                 self.suffix_array_rank_mem = sub_rank.to_vec();
 
@@ -664,6 +664,7 @@ where
                 }
             }
         }
+        self.suffix_array_mem_mql = Some(max_query_len);
 
         Ok(())
     }

--- a/libsufr/src/sufr_file.rs
+++ b/libsufr/src/sufr_file.rs
@@ -542,10 +542,8 @@ where
         {
             info!("Using existing suffix_array_mem");
             return Ok(());
-        }
-
-        // The requested MQL matches how the SA was built
-        if max_query_len == built_max_query_len {
+        } else if max_query_len == built_max_query_len {
+             // The requested MQL matches how the SA was built
             // Stuff entire SA into memory
             let now = Instant::now();
             self.suffix_array_file.reset();


### PR DESCRIPTION
Reworked the `set_suffix_array_mem` method of SufrFile (https://github.com/TravisWheelerLab/sufr/blob/main/libsufr/src/sufr_file.rs#L514C8-L514C28) to avoid redundant loading of the suffix array into memory:
1. If the query's `max_query_len` is `None`, it defaults to `self.text_len.to_usize()`, which will be equal to `built_max_query_len` if the suffix array was also built with `max_query_len` set to `None`. This means that every time `set_suffix_array_mem` is called, the condition on line 539 is triggered, leading to the entire suffix array being read from disk. If multiple queries are made with the Options `max_query_len: None`, the suffix array will be read every single time.
2. If the query len is different from the built query len, there is a condition for early-return if the loaded suffix array is nonempty and its internal max query len `self.suffix_array_mem_mql` matches the one from the Options. However, `self.suffix_array_mem_mql` is `None` by default and only gets set when the suffix array gets read from a non-cached file. 
3. Afaict, in every circumstance, by the end of `set_suffix_array_mem`, the suffix array in memory will have a max query len matching the Options max query len, so the change I made sets `self.suffix_array_mem_mql = Some(max_query_len)`; whenever the function does not return early.
4. To avoid the reloading issue in 1., I also moved the early-return in front of the other conditions, so that whenever a suffix array has been loaded into memory, and its max query length matches that of the Options' max query length, the method returns without doing redundant work.