### PR TITLE
Bisect for fast counting 

### DIFF
--- a/libsufr/src/suffix_array.rs
+++ b/libsufr/src/suffix_array.rs
@@ -151,20 +151,83 @@ impl SuffixArray {
     /// Bisect the index range of occurences of queries.
     /// If the index range of a prefix is already known,
     /// or if it is desirable to avoid enumerating every match,
-    // this method can be used as a faster stand-in for `count`
+    /// this method can be used as a faster stand-in for `count`
     /// ```
     /// use anyhow::Result;
-    /// use libsufr::{types::{BisectOptions, BisectResult}, sufr_file::SufrFile};
+    /// use libsufr::{types::{BisectOptions, BisectResult}, suffix_array::SuffixArray};
     ///
     /// fn main() -> Result<()> {
-    ///     let mut sufr = SufrFile::<u32>::read("../data/inputs/1.sufr", false)?;
+    ///     let mut suffix_array = SuffixArray::read("../data/inputs/1.sufr", false)?;
     ///     let opts = BisectOptions {
-    ///         queries: vec!["AC".to_string(), "AG".to_string(), "GT".to_string()],
+    ///         queries: vec!["A".to_string(), "AC".to_string(), "ACA".to_string(), "ACG".to_string(), "ACT".to_string(), "ACC".to_string()],
     ///         max_query_len: None,
-    ///         low_memory: true,
+    ///         low_memory: false,
     ///         prefix_result: None,
     ///     };
-    ///     let res = sufr.bisect(opts)?;
+    ///     let res = suffix_array.bisect(opts)?;
+    ///     let expected = vec![
+    ///         BisectResult { 
+    ///             query_num: 0, 
+    ///             query: "A".to_string(),  
+    ///             count: 2,  
+    ///             first_position: 1,  
+    ///             last_position: 2  
+    ///         },  
+    ///         BisectResult { 
+    ///             query_num: 1, 
+    ///             query: "AC".to_string(), 
+    ///             count: 2, 
+    ///             first_position: 1, 
+    ///             last_position: 2 
+    ///         }, 
+    ///         BisectResult { 
+    ///             query_num: 2, 
+    ///             query: "ACA".to_string(), 
+    ///             count: 0, 
+    ///             first_position: 0, 
+    ///             last_position: 0 
+    ///         }, 
+    ///         BisectResult { 
+    ///             query_num: 3, 
+    ///             query: "ACG".to_string(), 
+    ///             count: 2, 
+    ///             first_position: 1, 
+    ///             last_position: 2 
+    ///         }, 
+    ///         BisectResult { 
+    ///             query_num: 4, 
+    ///             query: "ACT".to_string(), 
+    ///             count: 0, 
+    ///             first_position: 0, 
+    ///             last_position: 0 
+    ///         }, 
+    ///         BisectResult {
+    ///             query_num: 5, 
+    ///             query: "ACC".to_string(), 
+    ///             count: 0, 
+    ///             first_position: 0, 
+    ///             last_position: 0 
+    ///         }
+    ///     ];
+    ///     assert_eq!(res, expected);
+    ///     
+    ///     let mut suffix_array = SuffixArray::read("../data/inputs/3.sufr", false)?;
+    ///     let opts1 = BisectOptions {
+    ///         queries: vec!["AC".to_string(), "ACA".to_string(), "ACG".to_string(), "ACT".to_string(), "ACC".to_string()],
+    ///         max_query_len: None,
+    ///         low_memory: false,
+    ///         prefix_result: None,
+    ///     };
+    ///     let res1 = suffix_array.bisect(opts1)?;
+    ///     let opts2 = BisectOptions {
+    ///         queries: vec!["AC".to_string(), "ACA".to_string(), "ACG".to_string(), "ACT".to_string(), "ACC".to_string()],
+    ///         max_query_len: None,
+    ///         low_memory: false,
+    ///         prefix_result: Some(res1[0].clone()),
+    ///     };
+    ///     let res2 = suffix_array.bisect(opts2)?;
+    ///     assert_eq!(res1, res2);
+    ///
     ///     Ok(())
     /// }
     /// ```

--- a/libsufr/src/suffix_array.rs
+++ b/libsufr/src/suffix_array.rs
@@ -155,79 +155,42 @@ impl SuffixArray {
     /// ```
     /// use anyhow::Result;
     /// use libsufr::{types::{BisectOptions, BisectResult}, suffix_array::SuffixArray};
-    ///
+    /// 
     /// fn main() -> Result<()> {
     ///     let mut suffix_array = SuffixArray::read("../data/inputs/1.sufr", false)?;
-    ///     let opts = BisectOptions {
-    ///         queries: vec!["A".to_string(), "AC".to_string(), "ACA".to_string(), "ACG".to_string(), "ACT".to_string(), "ACC".to_string()],
+    ///     let opts_without_prefix = BisectOptions {
+    ///         queries: vec!["AC".to_string(), "CG".to_string()],
     ///         max_query_len: None,
     ///         low_memory: false,
     ///         prefix_result: None,
     ///     };
-    ///     let res = suffix_array.bisect(opts)?;
-    ///     let expected = vec![
-    ///         BisectResult { 
-    ///             query_num: 0, 
-    ///             query: "A".to_string(),  
-    ///             count: 2,  
-    ///             first_position: 1,  
-    ///             last_position: 2  
-    ///         },  
-    ///         BisectResult { 
-    ///             query_num: 1, 
-    ///             query: "AC".to_string(), 
-    ///             count: 2, 
-    ///             first_position: 1, 
-    ///             last_position: 2 
-    ///         }, 
-    ///         BisectResult { 
-    ///             query_num: 2, 
-    ///             query: "ACA".to_string(), 
-    ///             count: 0, 
-    ///             first_position: 0, 
-    ///             last_position: 0 
-    ///         }, 
-    ///         BisectResult { 
-    ///             query_num: 3, 
-    ///             query: "ACG".to_string(), 
-    ///             count: 2, 
-    ///             first_position: 1, 
-    ///             last_position: 2 
-    ///         }, 
-    ///         BisectResult { 
-    ///             query_num: 4, 
-    ///             query: "ACT".to_string(), 
-    ///             count: 0, 
-    ///             first_position: 0, 
-    ///             last_position: 0 
-    ///         }, 
-    ///         BisectResult {
-    ///             query_num: 5, 
-    ///             query: "ACC".to_string(), 
-    ///             count: 0, 
-    ///             first_position: 0, 
-    ///             last_position: 0 
-    ///         }
-    ///     ];
-    ///     assert_eq!(res, expected);
-    ///     
-    ///     let mut suffix_array = SuffixArray::read("../data/inputs/3.sufr", false)?;
-    ///     let opts1 = BisectOptions {
-    ///         queries: vec!["AC".to_string(), "ACA".to_string(), "ACG".to_string(), "ACT".to_string(), "ACC".to_string()],
+    ///     let result_without_prefix = suffix_array.bisect(opts_without_prefix)?;
+    ///     assert_eq!(
+    ///         result_without_prefix,
+    ///         vec![
+    ///             BisectResult { query_num: 0, query: "AC".to_string(), count: 2, first_position: 1, last_position: 2 }, 
+    ///             BisectResult { query_num: 1, query: "CG".to_string(), count: 2, first_position: 3, last_position: 4 }]
+    ///     );
+    ///     let prefix_opts = BisectOptions {
+    ///         queries: vec!["A".to_string()],
     ///         max_query_len: None,
     ///         low_memory: false,
     ///         prefix_result: None,
     ///     };
-    ///     let res1 = suffix_array.bisect(opts1)?;
-    ///     let opts2 = BisectOptions {
-    ///         queries: vec!["AC".to_string(), "ACA".to_string(), "ACG".to_string(), "ACT".to_string(), "ACC".to_string()],
+    ///     let prefix_result = suffix_array.bisect(prefix_opts)?[0].clone();
+    ///     let opts_with_prefix = BisectOptions {
+    ///         queries: vec!["AC".to_string(), "CG".to_string()],
     ///         max_query_len: None,
     ///         low_memory: false,
-    ///         prefix_result: Some(res1[0].clone()),
+    ///         prefix_result: Some(prefix_result),
     ///     };
-    ///     let res2 = suffix_array.bisect(opts2)?;
-    ///     assert_eq!(res1, res2);
-    ///
+    ///     let result_with_prefix = suffix_array.bisect(opts_with_prefix)?;
+    ///     assert_eq!(
+    ///         result_with_prefix,
+    ///         vec![
+    ///             BisectResult { query_num: 0, query: "AC".to_string(), count: 2, first_position: 1, last_position: 2 }, 
+    ///             BisectResult { query_num: 1, query: "CG".to_string(), count: 0, first_position: 0, last_position: 0 }]
+    ///     );
     ///     Ok(())
     /// }
     /// ```

--- a/libsufr/src/sufr_file.rs
+++ b/libsufr/src/sufr_file.rs
@@ -671,7 +671,7 @@ where
     /// Bisect the index range of occurences of queries.
     /// If the index range of a prefix is already known,
     /// or if it is desirable to avoid enumerating every match,
-    // this method can be used as a faster stand-in for `count`
+    /// this method can be used as a faster stand-in for `count`
     /// ```
     /// use anyhow::Result;
     /// use libsufr::{types::{BisectOptions, BisectResult}, sufr_file::SufrFile};
@@ -679,12 +679,75 @@ where
     /// fn main() -> Result<()> {
     ///     let mut sufr = SufrFile::<u32>::read("../data/inputs/1.sufr", false)?;
     ///     let opts = BisectOptions {
-    ///         queries: vec!["AC".to_string(), "AG".to_string(), "GT".to_string()],
+    ///         queries: vec!["A".to_string(), "AC".to_string(), "ACA".to_string(), "ACG".to_string(), "ACT".to_string(), "ACC".to_string()],
     ///         max_query_len: None,
-    ///         low_memory: true,
+    ///         low_memory: false,
     ///         prefix_result: None,
     ///     };
     ///     let res = sufr.bisect(opts)?;
+    ///     let expected = vec![
+    ///         BisectResult { 
+    ///             query_num: 0, 
+    ///             query: "A".to_string(),  
+    ///             count: 2,  
+    ///             first_position: 1,  
+    ///             last_position: 2  
+    ///         },  
+    ///         BisectResult { 
+    ///             query_num: 1, 
+    ///             query: "AC".to_string(), 
+    ///             count: 2, 
+    ///             first_position: 1, 
+    ///             last_position: 2 
+    ///         }, 
+    ///         BisectResult { 
+    ///             query_num: 2, 
+    ///             query: "ACA".to_string(), 
+    ///             count: 0, 
+    ///             first_position: 0, 
+    ///             last_position: 0 
+    ///         }, 
+    ///         BisectResult { 
+    ///             query_num: 3, 
+    ///             query: "ACG".to_string(), 
+    ///             count: 2, 
+    ///             first_position: 1, 
+    ///             last_position: 2 
+    ///         }, 
+    ///         BisectResult { 
+    ///             query_num: 4, 
+    ///             query: "ACT".to_string(), 
+    ///             count: 0, 
+    ///             first_position: 0, 
+    ///             last_position: 0 
+    ///         }, 
+    ///         BisectResult {
+    ///             query_num: 5, 
+    ///             query: "ACC".to_string(), 
+    ///             count: 0, 
+    ///             first_position: 0, 
+    ///             last_position: 0 
+    ///         }
+    ///     ];
+    ///     assert_eq!(res, expected);
+    ///     
+    ///     let mut sufr = SufrFile::<u32>::read("../data/inputs/3.sufr", false)?;
+    ///     let opts1 = BisectOptions {
+    ///         queries: vec!["AC".to_string(), "ACA".to_string(), "ACG".to_string(), "ACT".to_string(), "ACC".to_string()],
+    ///         max_query_len: None,
+    ///         low_memory: false,
+    ///         prefix_result: None,
+    ///     };
+    ///     let res1 = sufr.bisect(opts1)?;
+    ///     let opts2 = BisectOptions {
+    ///         queries: vec!["AC".to_string(), "ACA".to_string(), "ACG".to_string(), "ACT".to_string(), "ACC".to_string()],
+    ///         max_query_len: None,
+    ///         low_memory: false,
+    ///         prefix_result: Some(res1[0].clone()),
+    ///     };
+    ///     let res2 = sufr.bisect(opts2)?;
+    ///     assert_eq!(res1, res2);
+    ///
     ///     Ok(())
     /// }
     /// ```

--- a/libsufr/src/sufr_file.rs
+++ b/libsufr/src/sufr_file.rs
@@ -1679,7 +1679,7 @@ mod test {
     // --------------------------------------------------
     #[test]
     fn test_bisect() -> Result<()> {
-        let mut sufr = SufrFile::<u32>::read("data/inputs/3.sufr", false)?;
+        let mut sufr = SufrFile::<u32>::read("../data/inputs/3.sufr", false)?;
         // bisect "A"
         let prefix = vec!["A".to_string()];
         let prefix_result = sufr.bisect(BisectOptions {

--- a/libsufr/src/sufr_search.rs
+++ b/libsufr/src/sufr_search.rs
@@ -3,7 +3,7 @@
 use crate::{
     file_access::FileAccess,
     types::{
-        Comparison, FromUsize, Int, SearchResult, SearchResultLocations, SuffixSortType,
+        Comparison, FromUsize, Int, BisectResult, SearchResult, SearchResultLocations, SuffixSortType,
     },
     util::find_lcp_full_offset,
 };
@@ -164,6 +164,36 @@ where
                 query_num,
                 query: query.to_string(),
                 locations: None,
+            })
+        }
+    }
+
+    pub fn bisect(
+        &mut self,
+        query_num: usize,
+        query: &str,
+        low: usize,
+        high: usize,
+    ) -> Result<BisectResult> {
+        let qry = query.as_bytes();
+        if let Some(start) = self.suffix_search_first(qry, low, high, 0, 0) {
+            // something was found
+            let end = self
+                .suffix_search_last(qry, start, high, high, 0, 0)
+                .unwrap_or(start);
+            Ok(BisectResult {
+                query_num: query_num,
+                query: query.to_string(),
+                first_position: start,
+                last_position: end,
+            })
+        } else {
+            // nothing was found
+            Ok(BisectResult {
+                query_num: query_num,
+                query: query.to_string(),
+                first_position: self.len_suffixes,
+                last_position: 0,
             })
         }
     }

--- a/libsufr/src/sufr_search.rs
+++ b/libsufr/src/sufr_search.rs
@@ -179,11 +179,12 @@ where
         if let Some(start) = self.suffix_search_first(qry, low, high, 0, 0) {
             // something was found
             let end = self
-                .suffix_search_last(qry, start, high, high, 0, 0)
+                .suffix_search_last(qry, start, high, high + 1, 0, 0)
                 .unwrap_or(start);
             Ok(BisectResult {
                 query_num: query_num,
                 query: query.to_string(),
+                count: end - start + 1,
                 first_position: start,
                 last_position: end,
             })
@@ -192,7 +193,8 @@ where
             Ok(BisectResult {
                 query_num: query_num,
                 query: query.to_string(),
-                first_position: self.len_suffixes,
+                count: 0,
+                first_position: 0,
                 last_position: 0,
             })
         }

--- a/libsufr/src/sufr_search.rs
+++ b/libsufr/src/sufr_search.rs
@@ -168,6 +168,17 @@ where
         }
     }
 
+
+    // --------------------------------------------------
+    /// Find the first and last positions of a query string in a suffix array,
+    /// given a range of viable positions.
+    /// Returns a `BisectResult`
+    ///
+    /// Args:
+    /// * `query_num`: ordinal number of the query
+    /// * `query`: a string to search for
+    /// * `low`: the lowest position at which the query may occur
+    /// * `high`: the highest position at which the query may occur
     pub fn bisect(
         &mut self,
         query_num: usize,

--- a/libsufr/src/types.rs
+++ b/libsufr/src/types.rs
@@ -365,7 +365,6 @@ pub struct BisectOptions {
 
 // --------------------------------------------------
 /// A struct representing the index range of occurrences of a suffix
-/// 
 #[derive(Debug, Clone, PartialEq)]
 pub struct BisectResult {
     /// The ordinal position of the original query
@@ -373,6 +372,9 @@ pub struct BisectResult {
 
     /// The query string
     pub query: String,
+
+    /// The width of the interval
+    pub count: usize,
 
     /// The first index of a suffix matching the query
     pub first_position: usize,

--- a/libsufr/src/types.rs
+++ b/libsufr/src/types.rs
@@ -345,6 +345,43 @@ impl FromUsize<u64> for u64 {
 }
 
 // --------------------------------------------------
+/// Options for bisecting the index ranges of occurrences of query suffixes
+#[derive(Debug, Clone)]
+pub struct BisectOptions {
+    /// Vector of query strings
+    pub queries: Vec<String>,
+
+    /// Maximum query length for search
+    pub max_query_len: Option<usize>,
+
+    /// When `true`, the suffix array will be placed into memory. 
+    /// When `false`, the suffix array will be read from disk.
+    pub low_memory: bool,
+
+    /// Optional, the bisect result for a query that is the common prefix of queries.
+    /// If passed, search for query ranges will be restricted to the range defined by prefix_result.
+    pub prefix_result: Option<BisectResult>,
+}
+
+// --------------------------------------------------
+/// A struct representing the index range of occurrences of a suffix
+/// 
+#[derive(Debug, Clone, PartialEq)]
+pub struct BisectResult {
+    /// The ordinal position of the original query
+    pub query_num: usize,
+
+    /// The query string
+    pub query: String,
+
+    /// The first index of a suffix matching the query
+    pub first_position: usize,
+
+    /// The last index of a suffix matching the query
+    pub last_position: usize,
+}
+
+// --------------------------------------------------
 /// Options for counting the occurrences of suffixes
 #[derive(Debug, Clone)]
 pub struct CountOptions {


### PR DESCRIPTION
Implements `types::{BisectOptions, BisectResult}` and the `bisect` methods in `SufrSearch`, `SufrFile`, and `SuffixArray`.

The bisect method finds the first and last positions of query strings as they occur in the suffix array. Using this range, the number of occurrences - the count - of each query is calculated without enumerating the range. 

If bisect has already been run on a prefix of the query sequence, the BisectResult of the prefix can be passed into the query BisectOptions via the optional `prefix_result` field. In this case, the bisect of the query will only search within range of positions occupied by the prefix.

Example:
```
use anyhow::Result;
use libsufr::{types::{BisectOptions, BisectResult}, suffix_array::SuffixArray};

fn main() -> Result<()> {
    let mut suffix_array = SuffixArray::read("data/inputs/3.sufr", false)?;

    let queries = vec!["AACTG".to_string(), "AAAA".to_string()];
    let prefix_query = vec!["AA".to_string()];

    let prefix_opts = BisectOptions {
        queries: prefix_query,
        max_query_len: None,
        low_memory: false,
        prefix_result: None, 
        // search the entire suffix array for query "AA"
    };
    let prefix_result = suffix_array.bisect(prefix_opts)?;
    assert_eq!(
        prefix_result,
        vec![
            BisectResult {
                query_num: 0,
                query: "AA".to_string(), 
                count: 11,
                first_position: 1,
                last_position: 11,
            }
        ]
    );

    let query_opts = BisectOptions {
        queries: queries,
        max_query_len: None,
        low_memory: false,
        prefix_result: Some(prefix_result[0].clone()), 
        // search within [prefix_result.first_position..=prefix_result.last_position]
    };
    let query_result = suffix_array.bisect(query_opts)?;
    assert_eq!(
        query_result,
        vec![
            BisectResult {
                query_num: 0,
                query: "AACTG".to_string(),
                count: 1,
                first_position: 8,
                last_position: 8,
            }, 
            BisectResult {
                query_num: 1,
                query: "AAAA".to_string(),
                count: 4,
                first_position: 1,
                last_position: 4,
            }
        ]
    );
    
    Ok(())
}
```